### PR TITLE
fix reference to heroku hobby postgres

### DIFF
--- a/app.json
+++ b/app.json
@@ -24,6 +24,6 @@
     }
   },
   "addons": [
-    "heroku-postgresql:hobby-dev"
+    "heroku-postgresql:basic"
   ]
 }


### PR DESCRIPTION
Heroku postgres no longer has a hobby-dev plan, but has a basic plan instead. Refactoring to reflect this.

https://devcenter.heroku.com/changelog-items/2502